### PR TITLE
Adopt a single allocation API

### DIFF
--- a/pasha/__init__.py
+++ b/pasha/__init__.py
@@ -77,11 +77,6 @@ def alloc(*args, **kwargs):
     return get_default_context().alloc(*args, **kwargs)
 
 
-@wraps(MapContext.alloc_per_worker)
-def alloc_per_worker(*args, **kwargs):
-    return get_default_context().alloc_per_worker(*args, **kwargs)
-
-
 @wraps(MapContext.map)
 def map(*args, **kwargs):
     return get_default_context().map(*args, **kwargs)

--- a/pasha/__init__.py
+++ b/pasha/__init__.py
@@ -72,19 +72,14 @@ def set_default_context(ctx_or_method, *args, **kwargs):
     _default_context = ctx
 
 
-@wraps(MapContext.array)
-def array(*args, **kwargs):
-    return get_default_context().array(*args, **kwargs)
+@wraps(MapContext.alloc)
+def alloc(*args, **kwargs):
+    return get_default_context().alloc(*args, **kwargs)
 
 
-@wraps(MapContext.array_like)
-def array_like(*args, **kwargs):
-    return get_default_context().array_like(*args, **kwargs)
-
-
-@wraps(MapContext.array_per_worker)
-def array_per_worker(*args, **kwargs):
-    return get_default_context().array_per_worker(*args, **kwargs)
+@wraps(MapContext.alloc_per_worker)
+def alloc_per_worker(*args, **kwargs):
+    return get_default_context().alloc_per_worker(*args, **kwargs)
 
 
 @wraps(MapContext.map)

--- a/pasha/context.py
+++ b/pasha/context.py
@@ -113,8 +113,8 @@ class MapContext:
 
         return np.empty(shape, dtype, order)
 
-    def alloc(self, shape=None, dtype=None, order=None, fill=None, like=None,
-              per_worker=False):
+    def alloc(self, shape=None, dtype=None, *,
+              order=None, fill=None, like=None, per_worker=False):
         """Allocate an array guaranteed to be shared with all workers.
 
         The implementation may decide how to back this memory, but it

--- a/pasha/context.py
+++ b/pasha/context.py
@@ -6,6 +6,8 @@
 # Copyright (c) 2020, European X-Ray Free-Electron Laser Facility GmbH.
 # All rights reserved.
 
+from numbers import Integral
+
 import numpy as np
 
 from .functor import Functor
@@ -39,56 +41,153 @@ class MapContext:
 
         self.num_workers = num_workers
 
-    def array(self, shape, dtype=np.float64):
-        """Allocate an array shared with all workers.
+    @staticmethod
+    def _resolve_alloc(shape, dtype, order, like):
+        """Resolve allocation arguments.
+
+        This method resolves the arguments passed to
+        :method:`MapContext.alloc` and fills any omitted values.
+
+        Returns:
+            (tuple, DtypeLike, str): Resolved shape, data-type and
+                memory order.
+        """
+        if like is not None:
+            shape = shape if shape is not None else like.shape
+            dtype = dtype if dtype is not None else like.dtype
+
+            try:
+                if order is None:
+                    # Check for C contiguity first, as one-dimensional
+                    # arrays may be both C and F-style at the same time.
+                    # If neither is the case, make the result C-style
+                    # anyway.
+                    if like.flags.c_contiguous:
+                        order = 'C'
+                    elif like.flags.f_contiguous:
+                        order = 'F'
+                    else:
+                        order = 'C'
+            except AttributeError:
+                # Existance of the flags property may not be considered
+                # required for an ArrayLike, so in case it's not just
+                # go for C-style.
+                order = 'C'
+
+        elif shape is None:
+            raise ValueError('array shape must be specified')
+
+        else:
+            dtype = dtype if dtype is not None else np.float64
+            order = order if order is not None else 'C'
+
+        if isinstance(shape, Integral):
+            shape = (shape,)
+        elif not isinstance(shape, tuple):
+            shape = tuple(shape)
+
+        return shape, dtype, order
+
+    @staticmethod
+    def _alloc(shape, dtype, order):
+        """Low-level allocation.
+
+        In most instances, it is recommended to use the high-level
+        method :method:`MapContext.alloc` instead. Context
+        implemenations can override this method to provide alternative
+        means of providing memory shared with all workers, e.g. via
+        shared memory segments across processes.
+
+        Note that none of the arguments of this method are optional.
+
+        The default implementation allocates directly on the heap.
+
+        Args:
+            shape (tuple): Shape of the array.
+            dtype (DtypeLike): Desired data-type for the array.
+            order ('C' or 'F') C-style or Fortran-style memory order.
+
+        Returns:
+            (numpy.ndarray) Created array object.
+        """
+
+        return np.empty(shape, dtype, order)
+
+    def alloc(self, shape=None, dtype=None, order=None, fill=None, like=None):
+        """Allocate an array guaranteed to be shared with all workers.
 
         The implementation may decide how to back this memory, but it
         is required that all workers of this context may read AND write
-        to this memory. The base implementation allocates directly
-        on the heap.
+        to this memory. By default, it allocates directly on the heap.
+
+        Only the shape argument is required for allocation to succeed,
+        however it may be omitted if an existing ArrayLike object is
+        passed via the like argument whose shape is taken.
+
+        The dtype and order arguments have the default values np.float64
+        and 'C' if omitted or are taken from the ArrayLike object passed
+        to like. Only C-style or Fortran-style order may be assumed to
+        be supported by all context implementations.
+
+        If fill is omitted, the resulting array is uninitialized.
+
+        Any specified argument always takes precedence over values
+        inferred from an ArrayLike object passed to like.
 
         Args:
-            shape (int or tuple of ints): Shape of the array.
-            dtype (data-type): Desired data-type for the array.
+            shape (int or tuple of ints, optional): Shape of the array.
+            dtype (DTypeLike, optional): Desired data-type for the array.
+            order ('C' or 'F', optional): Whether to store multiple
+                dimensions in row-major (C-style, default) or
+                column-major (Fortran-style).
+            fill (Scalar or ArrayLike, optional): Initialization value.
+            like (ArrayLike): Array to cope shape, dtype and order from.
 
         Returns:
             (numpy.ndarray) Created array object.
         """
 
-        return np.zeros(shape, dtype=dtype)
+        array = self._alloc(*self._resolve_alloc(shape, dtype, order, like))
 
-    def array_like(self, other):
-        """Allocate an array with the same shape and dtype as another.
+        if fill is not None:
+            array[:] = fill
 
-        Args:
-            other (ArrayLike): Other array.
+        return array
 
-        Returns:
-            (numpy.ndarray) Created array object.
-        """
-
-        return self.array(other.shape, other.dtype)
-
-    def array_per_worker(self, shape, dtype=np.float64):
+    def alloc_per_worker(self, shape=None, dtype=None, order=None, fill=None,
+                         like=None):
         """Allocate a shared array for each worker.
 
-        The returned array will contain an additional prepended axis
-        with its shape corresponding to the number of workers in this
-        context, i.e. with one dimension more than specified by the
-        shape parameter. These are useful for parallelized reduction
-        operations, where each worker may work with its own accumulator.
+        The returned array will contain an additional axis with its
+        shape corresponding to the number of workers in this context,
+        i.e. with one dimension more than specified by the shape
+        parameter. In row-major order (C-style) the axis is prepended,
+        in column-major order (Fortran-style) it is appended.
+
+        These are useful for parallelized reduction operations, where
+        each worker may work with its own accumulator, which are all
+        reduced after mapping (e.g. via sum).
 
         Args:
-            Same as array()
+            Same as alloc()
 
         Returns:
             (numpy.ndarray) Created array object.
         """
 
-        if isinstance(shape, int):
-            return self.array((self.num_workers, shape), dtype)
-        else:
-            return self.array((self.num_workers,) + tuple(shape), dtype)
+        shape, dtype, order = self._resolve_alloc(shape, dtype, order, like)
+
+        if order == 'C':
+            shape = (self.num_workers,) + shape
+        elif order == 'F':
+            shape = shape + (self.num_workers,)
+
+        array = self._alloc(shape, dtype, order)
+
+        if fill is not None:
+            array[:] = fill
+
+        return array
 
     def map(self, function, functor):
         """Apply a function to a functor.
@@ -240,13 +339,12 @@ class ProcessContext(PoolContext):
 
         self.id_queue = self.mp_ctx.Queue()
 
-    def array(self, shape, dtype=np.float64):
-        if isinstance(shape, int):
-            n_elements = shape
-        else:
-            n_elements = 1
-            for _s in shape:
-                n_elements *= _s
+    def _alloc(self, shape, dtype, order):
+        # Allocate shared memory via mmap.
+
+        n_elements = 1
+        for _s in shape:
+            n_elements *= _s
 
         import mmap
         n_bytes = n_elements * np.dtype(dtype).itemsize
@@ -256,8 +354,8 @@ class ProcessContext(PoolContext):
                         flags=mmap.MAP_SHARED | mmap.MAP_ANONYMOUS,
                         prot=mmap.PROT_READ | mmap.PROT_WRITE)
 
-        return np.frombuffer(memoryview(buf)[:n_bytes],
-                             dtype=dtype).reshape(shape)
+        return np.frombuffer(memoryview(buf)[:n_bytes], dtype=dtype) \
+            .reshape(shape, order=order)
 
     def map(self, function, functor):
         super().map(function, functor, self.mp_ctx.Pool)

--- a/pasha/tests/test_context.py
+++ b/pasha/tests/test_context.py
@@ -10,46 +10,90 @@ import pytest
 
 import numpy as np
 import pasha as psh
-from pasha.context import MapContext
+from pasha.context import MapContext, ProcessContext
 from pasha.functor import Functor
 
 
 @pytest.mark.parametrize(
-    ['shape_in', 'shape_out'], [(3, (3,)), ((3, 2), (3, 2))],
-    ids=['int', 'tuple'])
-def test_array(shape_in, shape_out):
-    """Test MapContext.array."""
-
-    ctx = MapContext(num_workers=1)
-
-    array = ctx.array(shape_in, np.uint32)
-    assert array.shape == shape_out
-    assert array.dtype == np.uint32
-
-
-def test_array_like():
-    """Test MapContext.array_like."""
-
-    ctx = MapContext(num_workers=1)
-
-    array_in = np.random.rand(2, 3, 4).astype(np.float32)
-    array_out = ctx.array_like(array_in)
-
-    assert array_in.shape == array_out.shape
-    assert array_in.dtype == array_out.dtype
-
-
+    'ctx_cls', [MapContext, ProcessContext],
+    ids=['MapContext', 'ProcessContext'])
+@pytest.mark.parametrize(
+    'method', ['alloc', 'alloc_per_worker'])
 @pytest.mark.parametrize(
     ['shape_in', 'shape_out'], [(3, (3,)), ((3, 2), (3, 2))],
     ids=['int', 'tuple'])
-def test_array_per_worker(shape_in, shape_out):
-    """Test MapContext.array_per_worker."""
+@pytest.mark.parametrize(
+    ['dtype_in', 'dtype_out'], [(None, np.float64), (np.uint16, np.uint16)],
+    ids=['default_dtype', 'fix_dtype'])
+@pytest.mark.parametrize(
+    ['order_in', 'order_flag'], [('C', 'c'), ('F', 'f')], ids=['C', 'Fortran'])
+@pytest.mark.parametrize(
+    'fill', [None, 0, 1, 42], ids=['empty', 'zero', 'one', 'real'])
+def test_alloc_direct(ctx_cls, method, shape_in, shape_out,
+                      dtype_in, dtype_out, order_in, order_flag, fill):
+    """Test direct allocation."""
 
-    ctx = MapContext(num_workers=4)
+    ctx = ctx_cls(num_workers=3)
 
-    array = ctx.array_per_worker(shape_in, np.uint32)
-    assert array.shape == (4,) + shape_out
-    assert array.dtype == np.uint32
+    array = getattr(ctx, method)(shape=shape_in, dtype=dtype_in,
+                                 order=order_in, fill=fill, like=None)
+
+    if method == 'alloc_per_worker':
+        if order_in == 'C':
+            assert array.shape == (ctx.num_workers,) + shape_out
+        elif order_in == 'F':
+            assert array.shape == shape_out + (ctx.num_workers,)
+    else:
+        assert array.shape == shape_out
+
+    assert array.dtype == dtype_out
+    assert getattr(array.flags, f'{order_flag}_contiguous')
+
+    if fill is not None:
+        np.testing.assert_allclose(array, fill)
+
+
+@pytest.mark.parametrize(
+    'ctx_cls', [MapContext, ProcessContext],
+    ids=['MapContext', 'ProcessContext'])
+@pytest.mark.parametrize(
+    'method', ['alloc', 'alloc_per_worker'])
+@pytest.mark.parametrize(
+    ['shape_in', 'shape_out'], [(None, (2, 3, 4)), ((6, 4), (6, 4))],
+    ids=['keep_shape', 'fix_shape'])
+@pytest.mark.parametrize(
+    ['dtype_in', 'dtype_out'], [(None, np.float32), (np.uint16, np.uint16)],
+    ids=['keep_dtype', 'fix_dtype'])
+@pytest.mark.parametrize(
+    ['order_like', 'order_in', 'order_flag'],
+    [('C', None, 'c'), ('F', None, 'f'), ('C', 'C', 'c'), ('F', 'F', 'f'),
+     ('C', 'F', 'f'), ('F', 'C', 'c')],
+    ids=['keep_C', 'keep_F', 'fix_CC', 'fix_FF', 'fix_CF', 'fix_FC'])
+@pytest.mark.parametrize(
+    'fill', [None, 0, 1, 42], ids=['empty', 'zero', 'one', 'real'])
+def test_alloc_like(ctx_cls, method, shape_in, shape_out, dtype_in, dtype_out,
+                    order_like, order_in, order_flag, fill):
+    """Test allocation based on existing ArrayLike."""
+
+    ctx = ctx_cls(num_workers=3)
+
+    array_in = np.random.rand(2, 3, 4).astype(np.float32, order=order_like)
+    array_out = getattr(ctx, method)(shape=shape_in, dtype=dtype_in,
+                                     order=order_in, fill=fill, like=array_in)
+
+    if method == 'alloc_per_worker':
+        if order_in == 'C':
+            assert array_out.shape == (ctx.num_workers,) + shape_out
+        elif order_in == 'F':
+            assert array_out.shape == shape_out + (ctx.num_workers,)
+    else:
+        assert array_out.shape == shape_out
+
+    assert array_out.dtype == dtype_out
+    assert getattr(array_out.flags, f'{order_flag}_contiguous')
+
+    if fill is not None:
+        np.testing.assert_allclose(array_out, fill)
 
 
 def test_run_worker():
@@ -82,7 +126,7 @@ def test_map(ctx):
     """Test map operation for each context type."""
 
     inp = np.random.rand(100)
-    outp = ctx.array(inp.shape, inp.dtype)
+    outp = ctx.alloc(shape=inp.shape, dtype=inp.dtype)
 
     def multiply(worker_id, index, value):
         outp[index] = 3 * value


### PR DESCRIPTION
Alternative implementation to address #5 next to #6 based on Thomas' idea of a single API call for the different allocation scenarios, for direct and per-worker arrays, respectively:

```
MapContext.alloc(shape=None, dtype=None, order=None, fill=None, like=None)
MapContext.alloc_per_worker(shape=None, dtype=None, order=None, fill=None, like=None)
```

It comes in 113 lines (!) lighter than the numpy array API, and I was quite chatty in its docstring 😃

I'm still tempted to fold the second method into a `per_worker` keyword, as it's really _just_ a flag to modify the result. This is nicely highlighted by the fact it's using the same test.
Also, one may make all arguments keyword-only, to ensure nobody is putting any meaning in its order. But it may be a bit too much on pushing a particular style.