### PR TITLE
WIP: Add decorators to modify map function behaviour

### DIFF
--- a/pasha/__init__.py
+++ b/pasha/__init__.py
@@ -10,10 +10,12 @@ __version__ = '0.1.2'
 
 from functools import wraps
 
-from .context import (
-    MapContext, SerialContext, ThreadContext, ProcessContext)  # noqa
+from .context import (  # noqa
+    MapContext, SerialContext, ThreadContext, ProcessContext)
 from .functor import (  # noqa
     SequenceFunctor, NdarrayFunctor, DataArrayFunctor, ExtraDataFunctor)
+from .util import (  # noqa
+    with_init, with_finalize, with_local_copies, with_reduction)
 
 
 _default_context = None

--- a/pasha/context.py
+++ b/pasha/context.py
@@ -41,6 +41,18 @@ class MapContext:
 
         self.num_workers = num_workers
 
+    def _run_hook(self, hook_type, function, *args):
+        try:
+            hooks = function._pasha_hooks_
+        except AttributeError:
+            # No _pasha_hooks_ attribute.
+            pass
+        else:
+            for hook in hooks:
+                function = getattr(hook, hook_type)(self, function, *args)
+
+        return function
+
     @staticmethod
     def _resolve_alloc(shape, dtype, order, like):
         """Resolve allocation arguments.
@@ -196,8 +208,7 @@ class MapContext:
 
         raise NotImplementedError('map')
 
-    @staticmethod
-    def run_worker(function, functor, share, worker_id):
+    def run_worker(self, function, functor, share, worker_id):
         """Main worker loop.
 
         This staticmethod contains the actual inner loop for a worker,
@@ -217,8 +228,12 @@ class MapContext:
             None
         """
 
+        function = self._run_hook('pre_worker', function, worker_id)
+
         for entry in functor.iterate(share):
             function(worker_id, *entry)
+
+        self._run_hook('post_worker', function, worker_id)
 
 
 class SerialContext(MapContext):
@@ -233,7 +248,10 @@ class SerialContext(MapContext):
 
     def map(self, function, functor):
         functor = Functor.try_wrap(functor)
+
+        function = self._run_hook('pre_map', function)
         self.run_worker(function, functor, next(iter(functor.split(1))), 0)
+        self._run_hook('post_map', function)
 
 
 class PoolContext(MapContext):
@@ -274,8 +292,10 @@ class PoolContext(MapContext):
         for worker_id in range(self.num_workers):
             self.id_queue.put(worker_id)
 
+        function = self._run_hook('pre_map', function)
         with pool_cls(self.num_workers, self.init_worker, (functor,)) as p:
             p.map(self.run_worker, functor.split(self.num_workers))
+        self._run_hook('post_map', function)
 
 
 class ThreadContext(PoolContext):

--- a/pasha/tests/test_util.py
+++ b/pasha/tests/test_util.py
@@ -1,0 +1,79 @@
+
+import numpy as np
+import pasha as psh
+from pasha.util import MapHook
+
+
+class HookedMapHook(MapHook):
+    """A hook for a hook. A Hookhook. A Hook²."""
+
+    def __init__(self, context, function):
+        self.context = context
+        self.function = function
+
+        self.pre_map_called = False
+        self.pre_worker_called = [False] * context.num_workers
+        self.kernel_called = False
+        self.post_worker_called = [False] * context.num_workers
+        self.post_map_called = False
+
+    def assert_called(self, pre_map, pre_worker, kernel, post_worker,
+                      post_map):
+        assert self.pre_map_called == pre_map
+        assert all([x == pre_worker for x in self.pre_worker_called])
+        assert self.kernel_called == kernel
+        assert all([x == post_worker for x in self.post_worker_called])
+        assert self.post_map_called == post_map
+
+    def pre_map(self, context, function):
+        assert context is self.context
+        assert function is self.function
+
+        self.assert_called(False, False, False, False, False)
+        self.pre_map_called = True
+
+        return function
+
+    def pre_worker(self, context, function, worker_id):
+        assert context is self.context
+        assert function is self.function
+
+        self.assert_called(True, False, False, False, False)
+        self.pre_worker_called[worker_id] = True
+
+        return function
+
+    def post_worker(self, context, function, worker_id):
+        assert context is self.context
+        assert function is self.function
+
+        self.assert_called(True, True, True, False, False)
+        self.post_worker_called[worker_id] = True
+
+        return function
+
+    def post_map(self, context, function):
+        assert context is self.context
+        assert function is self.function
+
+        self.assert_called(True, True, True, True, False)
+        self.post_map_called = True
+
+        return function
+
+
+def test_maphook():
+    def kernel(wid, index, data):
+        if index == 0:
+            hook.assert_called(True, True, False, False, False)
+            hook.kernel_called = True
+
+    ctx = psh.SerialContext()
+
+    hook = HookedMapHook(ctx, kernel)
+    hook(kernel)
+
+    inp = np.arange(10)
+    ctx.map(kernel, inp)
+
+    hook.assert_called(True, True, True, True, True)

--- a/pasha/util.py
+++ b/pasha/util.py
@@ -1,0 +1,227 @@
+
+from copy import copy, deepcopy
+from inspect import isgeneratorfunction
+from types import FunctionType
+
+import numpy as np
+
+
+class MapHook:
+    """Decorator to hook into the map process.
+
+    Applied to a map function, a map hook allows to intervene during the
+    map process, e.g. by changing the map function. Any number of hooks
+    may be applied to a single function, and each may run at one or more
+    stages.
+
+    There are four stages a hook can run in:
+
+    * pre_map: Runs just before the map operation starts on the host.
+    * pre_worker: Runs just before iteration starts in each worker.
+    * post_worker: Runs after iteration in each worker.
+    * post_map: Runs after the map operation on the host.
+
+    A hook implementation may override __init__ to collect its arguments
+    and any of the function corresponding to the stages it wants to
+    intervene in.
+    """
+
+    def __call__(self, function):
+        try:
+            hooks = function._pasha_hooks_
+        except AttributeError:
+            hooks = []
+            function._pasha_hooks_ = hooks
+
+        hooks.append(self)
+
+        return function
+
+    def _override_function_object(self, function, code=None, globals_=None,
+                                  name=None, argdefs=None, closure=None):
+        """Override one or more properties of a function object."""
+
+        new_function = FunctionType(
+            code=code or function.__code__,
+            globals=globals_ or function.__globals__,
+            name=name or function.__name__,
+            argdefs=argdefs or function.__defaults__,
+            closure=closure or function.__closure__
+        )
+
+        # Restore the _pasha_hooks_ attribute, which is guaranteed to be
+        # present by now.
+        new_function._pasha_hooks_ = function._pasha_hooks_
+
+        return new_function
+
+    def _inject_function_globals(self, function, globals_):
+        """Inject additional symbols into a function's global scope."""
+
+        return self._override_function_object(
+            function, globals_=dict(function.__globals__, **globals_))
+
+    def pre_map(self, context, function):
+        """Hook before the map operation starts."""
+
+        return function
+
+    def pre_worker(self, context, function, worker_id):
+        """Hook before a worker starts iterating."""
+
+        return function
+
+    def post_worker(self, context, function, worker_id):
+        """Hook before a worker starts iterating."""
+
+        return function
+
+    def post_map(self, context, function):
+        """Hook after the map operation ends."""
+
+        return function
+
+
+class with_init(MapHook):
+    """Hook to run an init function in each worker.
+
+    The function is run just before iteration takes place in the worker
+    and is passed the worker_id.
+
+    If it is a generator instead, all local variables of the init
+    function are inserted into the global scope of the map function.
+    """
+
+    def __init__(self, init_func):
+        self.init_func = init_func
+
+    def pre_worker(self, context, function, worker_id):
+        if isgeneratorfunction(self.init_func):
+            # If the init function is actually a generator, run it until
+            # its first yield statement and copy its local variables
+            # into the global scope of the kernel function.
+
+            init_gen = self.init_func(worker_id)
+            next(init_gen)  # Advance to the first yield.
+
+            # Create a new function object based on the previous one,
+            # adding our init function locals to the global dictionary.
+            function = self._inject_function_globals(
+                function, init_gen.gi_frame.f_locals.copy())
+        else:
+            # If the init function is just a function, simply run it.
+            self.init_func(worker_id)
+
+        return function
+
+
+class with_finalize(MapHook):
+    """Hook to run a finalize function in each worker.
+
+    The function is run just after iteration takes place in the worker
+    and is passed the worker_id and global scope dictionary of the map
+    function.
+    """
+
+    def __init__(self, del_func):
+        self.del_func = del_func
+
+    def post_worker(self, context, function, worker_id):
+        self.del_func(worker_id, function.__globals__)
+        return function
+
+
+class with_local_copies(MapHook):
+    """Hook to create local copies of global symbols in each worker.
+
+    Each worker creates a copy (optionally a deep copy) of the symbols
+    passed to the decorator just before iteration takes place, which are
+    injected into the global scope of the map function instead of the
+    original object. Each worker may then use this symbol independently
+    of the others, e.g. for caching.
+    """
+
+    def __init__(self, *symbols, deep=False):
+        self.symbols = symbols
+        self.deep = deep
+
+    def pre_worker(self, context, function, worker_id):
+        local_copies = {}
+
+        # Search the specified symbols in the function's global scope
+        # and store new copies of them.
+        for symbol in self.symbols:
+            try:
+                value = function.__globals__[symbol]
+            except KeyError:
+                pass
+            else:
+                local_copies[symbol] = deepcopy(value) \
+                    if self.deep else copy(value)
+
+        # Return a new function object replacing the original symbols by
+        # their copies.
+        return self._inject_function_globals(function, local_copies)
+
+
+class with_reduction(MapHook):
+    """Hook to automatize parallelized reduction.
+
+    A common pattern for data reduction is to allocate a seperate
+    reduction buffer for each worker, which are then reduced after the
+    map operation to yield a single result. This decorator allows to
+    manage such a case automatically, by creating local copies of the
+    final reduction buffer, replacing it in the map function's global
+    scope and reducing these per-worker copies afterwards into the
+    original buffer.
+
+    The symbols to use for reduction must be ArrayLike.
+    """
+
+    def __init__(self, *symbols, function=np.sum, kwargs=dict(axis=0)):
+        self.symbols = symbols
+        self.reduce_function = function
+        self.reduce_kwargs = kwargs
+
+    def pre_map(self, context, function):
+        self.per_worker_arrays = {}
+        self.result_scope = function.__globals__
+
+        # Find global symbols, allocate per-worker versions of it
+        for symbol in self.symbols:
+            try:
+                value = function.__globals__[symbol]
+                value.shape
+                value.dtype
+            except KeyError:
+                raise ValueError(f'reduction symbol {symbol} not found in '
+                                 f'function\'s global scope') from None
+            except AttributeError:
+                raise TypeError(f'reduction symbol {symbol} must be '
+                                f'ArrayLike') from None
+            else:
+                per_worker_array =  context.alloc_per_worker(like=value)
+                per_worker_array[:] = value
+                self.per_worker_arrays[symbol] = per_worker_array
+
+        return function
+
+    def pre_worker(self, context, function, worker_id):
+        # Pick the per-worker version and inject into function scope.
+        return self._inject_function_globals(
+            function, {symbol: per_worker_array[worker_id]
+                       for symbol, per_worker_array
+                       in self.per_worker_arrays.items()})
+
+    def post_map(self, context, function):
+        # Reduce the per-worker arrays into the global symbols.
+        for symbol in self.symbols:
+            self.reduce_function(
+                self.per_worker_arrays[symbol], out=self.result_scope[symbol],
+                **self.reduce_kwargs)
+
+        # Clear references to allow buffers to be collected.
+        self.per_worker_arrays.clear()
+        self.result_scope = None
+
+        return function


### PR DESCRIPTION
I've developed a few common patterns when using `pasha` and its spiritual predecessors, which can add up quite a bit of boilerplate at times and/or not fully work across all context types if implemented lazily.

I always wanted to somehow automatize or at least make these things more convenient, but I was wary of making `pasha`'s somewhat clean API more ugly with keywords and calls and such. Over the weekend, I had an inspiration on how one might get away with this as a purely optional feature. After some tests, it actually turned into a fully featured API to hook into various parts of the mapping process via decorators.

An example for the already implemented decorators:

a) Initialize/finalize a worker scope
```python
import numpy as np
import pasha as psh

outp = psh.alloc(shape=10, dtype=np.int32)

def prepare_some_values(worker_id):
    worker_id_plus_2 = worker_id + 2
    yield

def check_worker_ids(worker_id, scope):
    assert scope['worker_id_plus_2'] == worker_id + 2

@psh.with_init(prepare_some_values)
@psh.with_finalize(check_worker_ids)
def kernel(wid, index, row):
    outp[index] = worker_id_plus_2 - worker_id

psh.map(kernel, np.arange(10))
np.testing.assert_allclose(outp, 2)
```

b) Special case of a) for local buffers
```python
import numpy as np
import pasha as psh

psh.set_default_context('threads')  # test only works in same process.

buf = np.full(10, -1, dtype=np.int32)
local_bufs = psh.alloc_per_worker((), dtype=object)

@psh.with_local_copies('buf')
def kernel(wid, index, row):
    buf[:] = wid
    np.testing.assert_allclose(buf, wid)
    local_bufs[wid] = buf
    

psh.map(kernel, np.arange(10))
np.testing.assert_allclose(buf, -1)

for wid, local_buf in enumerate(local_bufs):
    np.testing.assert_allclose(local_buf, wid)
```

c) Automatize reduction
```python
import numpy as np
import pasha as psh

inp = np.tile(np.arange(10), [10, 1])
outp = psh.alloc(like=inp, shape=10, fill=0)

@psh.with_reduction('outp')
def kernel(wid, index, row):
    outp[:] += row

psh.map(kernel, inp)
np.testing.assert_allclose(inp.sum(axis=0), outp)
```

Any thoughts?

(The MRs compares against the `single_alloc_api` branch to keep the diff smaller)