### PR TITLE
Use codecov Github action v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python3 -m pytest -v --cov=pasha
+        python3 -m pytest -v --cov=pasha --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2


### PR DESCRIPTION
The v1 action is deprecated following some security concerns, and will stop working in a few months.

https://github.com/marketplace/actions/codecov